### PR TITLE
Use correct support for the const request API

### DIFF
--- a/src/dlsproto/client/request/GetRange.d
+++ b/src/dlsproto/client/request/GetRange.d
@@ -73,10 +73,10 @@ public struct Filter
 
 public struct Args
 {
-    cstring channel;
+    mstring channel;
     time_t lower_bound;
     time_t upper_bound;
-    cstring filter_string;
+    mstring filter_string;
     Filter.FilterMode filter_mode;
     RequestContext context;
 }

--- a/src/dlsproto/client/request/Put.d
+++ b/src/dlsproto/client/request/Put.d
@@ -33,9 +33,9 @@ public struct Args
 {
     import core.stdc.time;
 
-    cstring channel;
+    mstring channel;
     time_t timestamp;
-    Const!(void)[] value;
+    void[] value;
     RequestContext context;
 }
 


### PR DESCRIPTION
Instead of deserializing into the structure containing const fields,
we're now serializing const instance of the mutable struct (enabling us
to use the const API), but deserializing into the mutable struct.