### PR TITLE
Make double buffer works with the empty batches

### DIFF
--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -409,6 +409,12 @@ private scope class GetRangeHandler
             /// RecordStream consumes output buffer.
             private void[]* input;
 
+            /// Indicator if there's a (possibly empty) batch in the background
+            /// that was received, but never processed by the reader. We can't
+            /// use just input.length, since the batch we've received could be
+            /// zero-sized.
+            private bool pending_batch;
+
             /*******************************************************************
 
                 Initializes the double buffer
@@ -439,14 +445,41 @@ private scope class GetRangeHandler
 
             /*******************************************************************
 
+                Gets the next batch for processing.
+
                 Returns:
-                     false if there are no records in any of the buffers
+                    the slice to the next batch to process
 
             *******************************************************************/
 
-            private bool empty ()
+            private void[] getNextBatch ()
             {
-                return !this.output.length && !this.input.length;
+                this.pending_batch = false;
+                return *this.output;
+            }
+
+            /*******************************************************************
+
+                Clears the last processed batch.
+
+            *******************************************************************/
+
+            private void clearLastBatch ()
+            {
+                (*this.output).length = 0;
+            }
+
+            /*******************************************************************
+
+                Returns:
+                     false if there are no records in any of the buffers and
+                     there are no more batches to process lying in the background
+
+            *******************************************************************/
+
+            private bool has_more ()
+            {
+                return this.output.length || this.input.length || this.pending_batch;
             }
 
             /*******************************************************************
@@ -471,6 +504,8 @@ private scope class GetRangeHandler
                 auto old_len = (*input).length;
                 (*input).length = (*input).length + data.length;
                 (*input)[old_len..$] = data[];
+
+                this.pending_batch = true;
             }
         }
 
@@ -584,7 +619,7 @@ private scope class GetRangeHandler
                     this.outer.conn.flush();
                 }
 
-                Const!(void)[] remaining_batch = *this.buffers.output;
+                Const!(void)[] remaining_batch = this.buffers.getNextBatch();
                 for (uint yield_count = 0; remaining_batch.length; yield_count++)
                 {
                     if (yield_count >= 10) //yield every 10 records
@@ -609,9 +644,9 @@ private scope class GetRangeHandler
 
                 }
 
-                (*this.buffers.output).length = 0;
+                this.buffers.clearLastBatch();
 
-                if (this.stopped && this.buffers.empty())
+                if (this.stopped && !this.buffers.has_more())
                     break;
             }
 
@@ -632,7 +667,7 @@ private scope class GetRangeHandler
         private bool waitForRecords ()
         {
             // Wait for the next batch, unless we already have one.
-            if (this.buffers.empty())
+            if (!this.buffers.has_more())
             {
                 this.suspendFiber(FiberSuspended.WaitingForRecords);
             }
@@ -640,7 +675,7 @@ private scope class GetRangeHandler
             // Grab the back buffer and move it to the front
             this.buffers.swap();
 
-            return !this.stopped || !this.buffers.empty();
+            return !this.stopped || this.buffers.has_more();
         }
 
         /**********************************************************************

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -465,8 +465,12 @@ private scope class GetRangeHandler
                 if (!(*input).length)
                     enableStomping(*input);
 
-                (*input).length = data.length;
-                (*input)[] = data[];
+                // Note that the appending here is needed, since the node
+                // will send the remaining batch if received the Stop message
+                // during sending the batch.
+                auto old_len = (*input).length;
+                (*input).length = (*input).length + data.length;
+                (*input)[old_len..$] = data[];
             }
         }
 

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -632,7 +632,7 @@ private scope class GetRangeHandler
         private bool waitForRecords ()
         {
             // Wait for the next batch, unless we already have one.
-            if ((*this.buffers.input).length == 0)
+            if (this.buffers.empty())
             {
                 this.suspendFiber(FiberSuspended.WaitingForRecords);
             }


### PR DESCRIPTION
DoubleBuffer.empty() method was used to see if there are more batches
to process. However, since it would work solely by looking into the
buffer's length, that meant that DoubleBuffer could not detect that
there's an empty batch to process. This lead to the dead lock when the
node was waiting acknowledgement from the client that the batch was
received, but the client didn't know that there was a batch, never
acknowledging this.

Fixes #62