### PR TITLE
 Don't send the empty batch before Finished message 

### DIFF
--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -516,6 +516,11 @@ private scope class GetRangeHandler
 
         public void addRecords ( in void[] record_batch )
         {
+            if (record_batch.length == 0)
+            {
+                throw this.outer.conn.shutdownWithProtocolError("Received empty batch from the node");
+            }
+
             this.buffers.fill(record_batch);
 
             if (this.fiber_suspended == fiber_suspended.WaitingForRecords)

--- a/src/dlsproto/node/neo/request/GetRange.d
+++ b/src/dlsproto/node/neo/request/GetRange.d
@@ -266,8 +266,15 @@ public abstract scope class GetRangeProtocol_v1
 
             if(!got_next)
             {
-                this.sendBatchAndReceiveFeedback();
+                // No more data in the range. Ending request.
 
+                // Send the data remaining in the batch, if any
+                if ((*this.batch_buffer).length)
+                {
+                    this.sendBatchAndReceiveFeedback();
+                }
+
+                // Send finished message and wait on the ACK
                 this.ed.nextEvent(
                     this.ed.NextEventFlags.Receive,
                     (ed.Payload payload)


### PR DESCRIPTION
There's no point in sending the empty batch if it will be followed by
the Finished message. The finished message alone is enough to end the
request.

Fixes #62 

Alternative to #63 