### PR TITLE
Throw exception returned by shutdownWithProtocolError in GetRange

### DIFF
--- a/src/dlsproto/node/neo/request/GetRange.d
+++ b/src/dlsproto/node/neo/request/GetRange.d
@@ -746,7 +746,7 @@ public abstract scope class GetRangeProtocol_v0
                 state = state.Suspended;
                 break;
             default:
-                this.ed.shutdownWithProtocolError("invalid start state");
+                throw this.ed.shutdownWithProtocolError("invalid start state");
         }
 
         if ( !this.prepareChannel(channel_name) )


### PR DESCRIPTION
In one place, the exception returned by `shutdownWithProtocol` error
wasn't thrown.