### PR TITLE
D2: Make sure the correct 'RequestContext' type is picked

### DIFF
--- a/src/dlsproto/client/mixins/NeoSupport.d
+++ b/src/dlsproto/client/mixins/NeoSupport.d
@@ -359,7 +359,7 @@ template NeoSupport ()
         import ocean.task.Task;
 
         import swarm.neo.client.mixins.TaskBlockingCore;
-        import swarm.neo.client.request_options.RequestContext;
+        import swarm.neo.client.request_options.RequestContext : RequestContext;
 
         /***********************************************************************
 


### PR DESCRIPTION
Otherwise this result in a static assert being triggered, mentioning that RequestContext is not handled.