### PR TITLE
Add helper method makeGroupRequest

### DIFF
--- a/relnotes/makegroup.feature.md
+++ b/relnotes/makegroup.feature.md
@@ -1,0 +1,12 @@
+### Add helper method to create GroupRequest
+
+* `dlsproto.client.legacy.internal.helper.GroupRequest`
+
+  Previously, to instantiate the GroupRequest, the user had to pass the request
+  struct as a template parameter, since the constructor wouldn't deduce it.
+  Now the helper method `makeGroupRequest` is added which instantiates and
+  returns the right `GroupRequest` instance without the need for the user to
+  specify the template parameters. This is especially important when using the
+  DMD 2.071.x where accessing the private request structs inside DlsClient
+  is deprecated.
+


### PR DESCRIPTION
Since DMD 2.071.* the request structs are private for the client. This
means that it's deprecated to refer the request struct when
instantiating the GroupRequest template. As an alternative,
makeGroupRequest function template that deducts the type of the
GroupRequest from the instance parameter is added.