### PR TITLE
Raise stopped notification if request ends as the result of the stop()

### DIFF
--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -169,13 +169,20 @@ public struct GetRange
     {
         auto context = This.getContext(context_blob);
 
-        if (!context.shared_working.stopped)
+        Notification notification;
+
+        if (context.shared_working.stopped)
+        {
+            // Stopped notification instead of the final one
+            notification.stopped = NoInfo();
+        }
+        else
         {
             // Final notification, after the request has been finished
-            Notification notification;
             notification.finished = NoInfo();
-            GetRange.notify(context.user_params, notification);
         }
+
+        GetRange.notify(context.user_params, notification);
     }
 }
 


### PR DESCRIPTION
The stopped notification was missing, however code that was preventing
finished notification was in place, resulting in the user lacking both
stopped and finished notifications in case GetRange.stop() was used.