### PR TITLE
Add DlsClient constructor accepting neo but not legacy configuration

### DIFF
--- a/src/dlsproto/client/DlsClient.d
+++ b/src/dlsproto/client/DlsClient.d
@@ -744,6 +744,34 @@ public class DlsClient : IClient
         this.node_handshake = new NodeHandshake;
     }
 
+     /***************************************************************************
+
+        Constructor with support for neo and legacy protocols. Accepts only
+        `Neo.Config`, not `IClient.Config`, for applications that use the neo
+        protocol only.
+
+        Params:
+            epoll = EpollSelectDispatcher instance to use
+            neo_config = swarm.neo.client.mixins.ClientCore.Config instance.
+                (The Config class is designed to be read from an application's
+                config.ini file via ocean.util.config.ConfigFiller.)
+            conn_notifier = delegate which is called when a connection attempt
+                succeeds or fails (including when a connection is
+                re-established). Of type:
+                void delegate ( IPAddress node_address, Exception e )
+
+    ***************************************************************************/
+
+    public this ( EpollSelectDispatcher epoll, Neo.Config neo_config,
+        Neo.ConnectionNotifier conn_notifier )
+    {
+        this(epoll, IClient.Config.default_connection_limit,
+            IClient.Config.default_queue_size,
+            IClient.default_fiber_stack_size);
+
+        this.neoInit(neo_config, conn_notifier);
+    }
+
 
     /***************************************************************************
 

--- a/src/dlsproto/client/DlsClient.d
+++ b/src/dlsproto/client/DlsClient.d
@@ -258,7 +258,7 @@ public class ExtensibleDlsClient ( Plugins ... ) : DlsClient
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exceptgion e )
+                void delegate ( Neo.ConnNotification )
             fiber_stack_size = size (in bytes) of stack of individual connection
                 fibers.
 
@@ -292,7 +292,7 @@ public class ExtensibleDlsClient ( Plugins ... ) : DlsClient
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exception e )
+                void delegate ( Neo.ConnNotification )
             conn_limit  = maximum number of connections in pool
             queue_size = size (in bytes) of per-node queue of pending requests
             fiber_stack_size = size (in bytes) of stack of individual connection
@@ -406,7 +406,7 @@ public class SchedulingDlsClient : ExtensibleDlsClient!(RequestScheduler)
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exceptgion e )
+                void delegate ( Neo.ConnNotification )
             fiber_stack_size = size (in bytes) of stack of individual connection
                 fibers.
 
@@ -441,7 +441,7 @@ public class SchedulingDlsClient : ExtensibleDlsClient!(RequestScheduler)
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exception e )
+                void delegate ( Neo.ConnNotification )
             conn_limit  = maximum number of connections in pool
             queue_size = size (in bytes) of per-node queue of pending requests
             fiber_stack_size = size (in bytes) of stack of individual connection
@@ -758,7 +758,7 @@ public class DlsClient : IClient
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exception e )
+                void delegate ( Neo.ConnNotification )
 
     ***************************************************************************/
 
@@ -790,7 +790,7 @@ public class DlsClient : IClient
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exceptgion e )
+                void delegate ( Neo.ConnNotification )
             fiber_stack_size = size (in bytes) of stack of individual connection
                 fibers.
 
@@ -829,7 +829,7 @@ public class DlsClient : IClient
             conn_notifier = delegate which is called when a connection attempt
                 succeeds or fails (including when a connection is
                 re-established). Of type:
-                void delegate ( IPAddress node_address, Exception e )
+                void delegate ( Neo.ConnNotification )
             conn_limit  = maximum number of connections in pool
             queue_size = size (in bytes) of per-node queue of pending requests
             fiber_stack_size = size (in bytes) of stack of individual connection


### PR DESCRIPTION
In case legacy configuration is not needed to be configured through
the Config file, the new constructor may be used that still initializes
legacy protocol, but accepts config file only for the Neo.