### PR TITLE
GetRange notification types started, suspended and resumed are removed

### DIFF
--- a/relnotes/nostart.migration.md
+++ b/relnotes/nostart.migration.md
@@ -1,0 +1,9 @@
+### GetRange notification types started, suspended and resumed are removed
+
+Since the GetRange v1, the request is immediately ready to be suspended,
+and it also suspends and resumes instantly, without waiting for the nodes.
+This makes `started`, `suspended` and `resumed` notification types useless
+and they are now removed. The code inside the `started` notification should be
+moved to be executed after creating the request, and the code for suspend/resume
+should be removed and it should be assumed that the client will suspend/resume
+immediately.

--- a/src/dlsproto/client/UsageExamples.d
+++ b/src/dlsproto/client/UsageExamples.d
@@ -372,11 +372,7 @@ unittest
         /// Suspendable instance
         private DlsClient.Neo.Suspendable!(DlsClient.Neo.GetRange.IController) suspendable;
 
-        // Notifier for the GetRange request below. This attaches the
-        // suspendable to the throttler after request is started. In addition
-        // notifier must call suspendable.handlePending() after previously
-        // initiated state-change has been completed (i.e. on suspended or
-        // resumed).
+        // Notifier for the GetRange request below.
         void getRangeNotifier ( DlsClient.Neo.GetRange.Notification info,
             DlsClient.Neo.GetRange.Args args )
         {

--- a/src/dlsproto/client/request/GetRange.d
+++ b/src/dlsproto/client/request/GetRange.d
@@ -90,11 +90,6 @@ public struct Args
 
 public union NotificationUnion
 {
-    /// All known nodes have either started handling the request or are not
-    /// currently connected. The request may now be suspended / resumed /
-    /// stopped, via the controller.
-    NoInfo started;
-
     /// A value is received from a node.
     RequestRecordInfo received;
 
@@ -109,14 +104,6 @@ public union NotificationUnion
     /// The request was tried on a node and failed because it is unsupported;
     /// it will be continued on any remaining nodes.
     RequestNodeUnsupportedInfo unsupported;
-
-    /// All known nodes have either suspended the request (as requested by the
-    /// user, via the controller) or are not currently connected.
-    NoInfo suspended;
-
-    /// All known nodes have either resumed the request (as requested by the
-    /// user, via the controller) or are not currently connected.
-    NoInfo resumed;
 
     /// All known nodes have either stopped the request (as requested by the
     /// user, via the controller) or are not currently connected. The request is


### PR DESCRIPTION
Since the GetRange v1, the request is immediately ready to be suspended,
and it also suspends and resumes instantly, without waiting for the
nodes.  This makes `started`, `suspended` and `removed` notification
types useless and they are now removed. The `started` notification
should be replaced with the code that follows the creation of the
request, and the code for suspend/resume should be removed and it should
be assumed that the client will suspend/resume immediately.