### PR TITLE
 Timeout waiting for the Stopped acknowledgement after one minute

### DIFF
--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/dlang:v2
+FROM sociomantictsunami/dlang:v3

--- a/src/dlsproto/client/README.rst
+++ b/src/dlsproto/client/README.rst
@@ -58,3 +58,12 @@ that there are two ways to assign some requests:
    blocking manner -- the current task will be suspended until the assigned
    request is finished.
 
+Controlling Requests
+...................
+
+Once the request is started and the request id is stored, user may use
+``Controller`` to suspend/resume/stop the request (in case of ``GetRange``
+request). Note that ``stop`` will wait for the node to respond with the `Stopped`
+message for a reasonable time period (one minute). If node doesn't respond
+with the stop acknowledgment, the client will just end the request on that
+node.

--- a/src/dlsproto/client/mixins/NeoSupport.d
+++ b/src/dlsproto/client/mixins/NeoSupport.d
@@ -813,7 +813,7 @@ template NeoSupport ()
         Neo.ConnectionNotifier conn_notifier )
     {
         this.neo = new Neo(auth_name, auth_key,
-                        Neo.Settings(conn_notifier, new SharedResources));
+                        Neo.Settings(conn_notifier, new SharedResources(this.epoll)));
         this.neo.enableSocketNoDelay();
         this.blocking = new TaskBlocking;
     }
@@ -838,7 +838,7 @@ template NeoSupport ()
     private void neoInit ( Neo.Config config,
         Neo.ConnectionNotifier conn_notifier )
     {
-        this.neo = new Neo(config, Neo.Settings(conn_notifier, new SharedResources));
+        this.neo = new Neo(config, Neo.Settings(conn_notifier, new SharedResources(this.epoll)));
         this.neo.enableSocketNoDelay();
         this.blocking = new TaskBlocking;
     }


### PR DESCRIPTION
GetRange may be constantly held in the position where the node
doesn't acknowledge the sent Stop control message. To prevent locking,
GetRange now waits for up to 60 seconds before proceeding, no matter
what the node said.