### PR TITLE
Enable TCP_NODELAY on neo connections

### DIFF
--- a/src/dlsproto/client/mixins/NeoSupport.d
+++ b/src/dlsproto/client/mixins/NeoSupport.d
@@ -814,6 +814,7 @@ template NeoSupport ()
     {
         this.neo = new Neo(auth_name, auth_key,
                         Neo.Settings(conn_notifier, new SharedResources));
+        this.neo.enableSocketNoDelay();
         this.blocking = new TaskBlocking;
     }
 
@@ -838,6 +839,7 @@ template NeoSupport ()
         Neo.ConnectionNotifier conn_notifier )
     {
         this.neo = new Neo(config, Neo.Settings(conn_notifier, new SharedResources));
+        this.neo.enableSocketNoDelay();
         this.blocking = new TaskBlocking;
     }
 }


### PR DESCRIPTION
This enables the nodelay on the Neo client, so the user doesn't
need to do this. In the next swarm version this will be done
automatically.