### PR TITLE
Don't use deprecated methods if using swarm v5.1.x+

### DIFF
--- a/src/dlsproto/client/legacy/internal/connection/DlsRequestConnection.d
+++ b/src/dlsproto/client/legacy/internal/connection/DlsRequestConnection.d
@@ -118,6 +118,7 @@ public class DlsRequestConnection :
         : RequestResources, IDlsRequestResources
     {
         import swarm.Const : NodeItem;
+        import swarm.util.RecordBatcher;
 
 
         /***********************************************************************
@@ -224,7 +225,7 @@ public class DlsRequestConnection :
 
         override protected mstring new_batch_buffer ( )
         {
-            return new char[RecordBatch.DefaultMaxBatchSize];
+            return new char[RecordBatcher.DefaultMaxBatchSize];
         }
 
 

--- a/src/dlsproto/client/mixins/NeoSupport.d
+++ b/src/dlsproto/client/mixins/NeoSupport.d
@@ -63,6 +63,7 @@ template NeoSupport ()
     import swarm.neo.client.request_options.RequestOptions;
     import core.stdc.time;
     import ocean.core.Verify;
+    import ocean.core.VersionCheck;
 
     public import dlsproto.common.GetRange;
 
@@ -814,7 +815,11 @@ template NeoSupport ()
     {
         this.neo = new Neo(auth_name, auth_key,
                         Neo.Settings(conn_notifier, new SharedResources(this.epoll)));
-        this.neo.enableSocketNoDelay();
+        // deprecated, remove in next major
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+        {
+            this.neo.enableSocketNoDelay();
+        }
         this.blocking = new TaskBlocking;
     }
 
@@ -839,7 +844,11 @@ template NeoSupport ()
         Neo.ConnectionNotifier conn_notifier )
     {
         this.neo = new Neo(config, Neo.Settings(conn_notifier, new SharedResources(this.epoll)));
-        this.neo.enableSocketNoDelay();
+        // deprecated, remove in next major
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+        {
+            this.neo.enableSocketNoDelay();
+        }
         this.blocking = new TaskBlocking;
     }
 }

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -21,6 +21,7 @@ module dlsproto.client.request.internal.GetRange;
 import core.stdc.time;
 
 import ocean.transition;
+import ocean.core.VersionCheck;
 import ocean.core.Verify;
 import ocean.util.log.Logger;
 
@@ -598,7 +599,11 @@ private scope class GetRangeHandler
                         }
                     );
 
-                    this.outer.conn.flush();
+                    // deprecated, remove in the next major
+                    static if (!hasFeaturesFrom!("swarm", 5, 1))
+                    {
+                        this.outer.conn.flush();
+                    }
                 }
 
                 Const!(void)[] remaining_batch = *this.buffers.output;
@@ -920,7 +925,11 @@ private scope class GetRangeHandler
                                 payload.addCopy(MessageType_v2.Stop);
                             }
                         );
-                        this.outer.conn.flush();
+                        // deprecated, remove in the next major
+                        static if (!hasFeaturesFrom!("swarm", 5, 1))
+                        {
+                            this.outer.conn.flush();
+                        }
                         this.outer.context.shared_working.stopped = true;
 
                         // set the timer to timeout if the node haven't responded

--- a/src/dlsproto/node/neo/request/GetRange.d
+++ b/src/dlsproto/node/neo/request/GetRange.d
@@ -13,6 +13,7 @@
 module dlsproto.node.neo.request.GetRange;
 
 import ocean.util.log.Logger;
+import ocean.core.VersionCheck;
 import swarm.neo.node.IRequestHandler;
 
 /*******************************************************************************
@@ -362,7 +363,11 @@ public abstract class GetRangeProtocol_v2: IRequestHandler
         switch (event.active)
         {
             case event.active.sent:
-                this.ed.flush();
+                // deprecated, remove in next major
+                static if (!hasFeaturesFrom!("swarm", 5, 1))
+                {
+                    this.ed.flush();
+                }
                 // Records sent: wait for Continue/Stop feedback, ACK Stop
                 // stop and return true for Continue or false for stop
                 switch (this.ed.receiveValue!(MessageType_v2)())
@@ -438,7 +443,11 @@ public abstract class GetRangeProtocol_v2: IRequestHandler
             }
         );
 
-        this.ed.flush();
+        // deprecated, remove in next major
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+        {
+            this.ed.flush();
+        }
     }
 
 

--- a/src/dlstest/DlsClient.d
+++ b/src/dlstest/DlsClient.d
@@ -21,6 +21,7 @@ module dlstest.DlsClient;
 
 import ocean.transition;
 import ocean.core.Verify;
+import ocean.core.VersionCheck;
 import ocean.util.log.Logger;
 
 /******************************************************************************
@@ -369,7 +370,11 @@ class DlsClient
         this.raw_client = new RawClient(theScheduler.epoll, auth_name,
             auth_key.content,
             &this.neo.connectionNotifier, max_connections);
-        this.raw_client.neo.enableSocketNoDelay();
+        // deprecated, remove in next major
+        static if (!hasFeaturesFrom!("swarm", 5, 1))
+        {
+            this.raw_client.neo.enableSocketNoDelay();
+        }
     }
 
     /**************************************************************************


### PR DESCRIPTION
This avoids using methods deprecated in swarm v5.1.0, if using that version of swarm.