### PR TITLE
Always resume RecordStream fiber when user issues stop

### DIFF
--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -569,8 +569,11 @@ private scope class GetRangeHandler
                 this.outer.timer.cancel();
 
             this.stopped = true;
-            if (this.fiber_suspended == fiber_suspended.WaitingForRecords)
+            if (this.fiber_suspended == fiber_suspended.WaitingForRecords ||
+                this.fiber_suspended == fiber_suspended.RequestSuspended)
+            {
                 this.resumeFiber();
+            }
         }
 
         /**********************************************************************


### PR DESCRIPTION
Previously, if `RecordStream` was suspended, issuing a `stop`
from a controller would resume it only if is waiting for the node
to deliver more data. This however doesn't work if user suspended
the request, and while suspended, they try to stop it (one example
of this situation would be where the user stops the request when
receiving node_disconnected, which by definition gets dispatched
asynchronously from the request).

Now the RecordStream is resumed if it's waiting for the records
from the node or if it's suspended explicitly.