### PR TITLE
Do not resume GetRange RoC after reconnecting

### DIFF
--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -222,6 +222,9 @@ private scope class GetRangeHandler
     /// Request event dispatcher
     private RequestEventDispatcher request_event_dispatcher;
 
+    /// Indicator if the request started on this connection
+    private bool request_started;
+
     /***************************************************************************
 
         Constructor.
@@ -272,6 +275,12 @@ private scope class GetRangeHandler
 
     private bool connect ( )
     {
+        // if the request started already, don't restart upon reconnecting,
+        // since GetRange is not (yet) capable of resuming from the interruption
+        // point, leading to the duplicate data received by the client
+        if (this.request_started)
+            return false;
+
         return batchRequestConnector(this.conn);
     }
 
@@ -338,6 +347,8 @@ private scope class GetRangeHandler
                 GetRange.notify(this.context.user_params, n);
                 return;
         }
+
+        this.request_started = true;
 
         scope record_stream = this.new RecordStream;
         scope reader = this.new Reader(record_stream);


### PR DESCRIPTION
After moving to BatchRequestCore framework, the design decision
where the GetRange should not restart after reconnecting was dropped.
This makes the GetRange not resume after reconnecting.