### PR TITLE
Unregister the timer and remove it from the SelectedKeysHandler list

### DIFF
--- a/src/dlsproto/client/internal/SharedResources.d
+++ b/src/dlsproto/client/internal/SharedResources.d
@@ -393,7 +393,8 @@ public final class SharedResources
         public void cancel ( )
         {
             this.enabled = false;
-            this.outer.epoll.unregister(this.timer);
+            // remove it from the client list as well as unregister it
+            this.outer.epoll.unregister(this.timer, true);
         }
 
         /***********************************************************************


### PR DESCRIPTION
This unregisters the timer from the epoll, but it also removes it
from the set of ready select clients to handle, in it's ready to fire,
but the request was already out of the scope.