### PR TITLE
Fix missing import for builds without unittest version

### DIFF
--- a/src/turtle/env/Dls.d
+++ b/src/turtle/env/Dls.d
@@ -21,6 +21,7 @@ module turtle.env.Dls;
 
 *******************************************************************************/
 
+import ocean.core.Test : TestException;
 import ocean.transition;
 import ocean.core.Verify;
 


### PR DESCRIPTION
Compiling turtle tests fail because the `waitTotalRecords` uses TestException that is imported only for unittest builds.