### PR TITLE
Fix imports to allow compilation with dmd 2.087

### DIFF
--- a/src/dlsproto/client/mixins/NeoSupport.d
+++ b/src/dlsproto/client/mixins/NeoSupport.d
@@ -114,8 +114,8 @@ template NeoSupport ()
 
         private struct Internals
         {
-            import dlsproto.client.request.internal.Put;
-            import dlsproto.client.request.internal.GetRange;
+            public import dlsproto.client.request.internal.Put;
+            public import dlsproto.client.request.internal.GetRange;
         }
 
         /***********************************************************************

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -67,7 +67,7 @@ public struct GetRange
 {
     import dlsproto.common.GetRange;
     import dlsproto.common.RequestCodes;
-    import dlsproto.client.request.GetRange;
+    public import dlsproto.client.request.GetRange;
     import dlsproto.client.internal.SharedResources;
 
     import ocean.io.select.protocol.generic.ErrnoIOException: IOError;
@@ -203,7 +203,7 @@ private scope class GetRangeHandler
     import swarm.neo.util.MessageFiber;
 
 
-    alias GetRange.BatchRequestSharedWorkingData.Signal ControllerSignal;
+    alias swarm.neo.client.mixins.BatchRequestCore.BatchRequestSharedWorkingData.Signal ControllerSignal;
 
     /// Resumes the `RecordStream` fiber.
     private static immutable ubyte ResumeRecordStreamValue = ControllerSignal.max + 1;


### PR DESCRIPTION
This does not address the use of deprecated features, which still generate dozens of warnings, but it does fix the errors.

* The swarm mixins need access to the Notification type, so the imports of the Requests need to be made public.

*  The GetRange request uses ambiguous symbols at a couple of places.
