### PR TITLE
Replace `Const!` with `const`

### DIFF
--- a/neotest/main.d
+++ b/neotest/main.d
@@ -99,7 +99,7 @@ class GetRangeTest : DlsTest
     }
 
     protected void getRangeNotifier ( DlsClient.Neo.GetRange.Notification info,
-        Const!(DlsClient.Neo.GetRange.Args) args )
+        const(DlsClient.Neo.GetRange.Args) args )
     {
         with ( info.Active ) switch ( info.active )
         {

--- a/src/dlsproto/client/NotifierTypes.d
+++ b/src/dlsproto/client/NotifierTypes.d
@@ -27,5 +27,5 @@ public struct RequestRecordInfo
 
     RequestId request_id;
     time_t key;
-    Const!(void)[] value;
+    const(void)[] value;
 }

--- a/src/dlsproto/client/UsageExamples.d
+++ b/src/dlsproto/client/UsageExamples.d
@@ -155,7 +155,7 @@ unittest
         // details of the parameters of the notifier. (Each request has a
         // module like this, defining its public API.)
         private void putNotifier ( DlsClient.Neo.Put.Notification info,
-            Const!(DlsClient.Neo.Put.Args) args )
+            const(DlsClient.Neo.Put.Args) args )
         {
             formatNotification(info, this.msg_buf);
 
@@ -202,7 +202,7 @@ unittest
         // details of the parameters of the notifier. (Each request has a
         // module like this, defining its public API.)
         private void putNotifier ( DlsClient.Neo.Put.Notification info,
-            Const!(DlsClient.Neo.Put.Args) args )
+            const(DlsClient.Neo.Put.Args) args )
         {
             formatNotification(info, this.msg_buf);
 
@@ -307,7 +307,7 @@ unittest
         // details of the parameters of the notifier. (Each request has a
         // module like this, defining its public API.)
         private void getRangeNotifier ( DlsClient.Neo.GetRange.Notification info,
-            Const!(DlsClient.Neo.GetRange.Args) args )
+            const(DlsClient.Neo.GetRange.Args) args )
         {
             formatNotification(info, this.msg_buf);
 
@@ -375,7 +375,7 @@ unittest
 
         // Notifier for the GetRange request below.
         void getRangeNotifier ( DlsClient.Neo.GetRange.Notification info,
-            Const!(DlsClient.Neo.GetRange.Args) args )
+            const(DlsClient.Neo.GetRange.Args) args )
         {
             formatNotification(info, this.msg_buf);
 

--- a/src/dlsproto/client/legacy/internal/request/params/IODelegates.d
+++ b/src/dlsproto/client/legacy/internal/request/params/IODelegates.d
@@ -55,7 +55,7 @@ import swarm.util.RecordBatcher;
 
 *******************************************************************************/
 
-public alias Const!(char[]) delegate (RequestContext) PutValueDg;
+public alias const(char[]) delegate (RequestContext) PutValueDg;
 
 
 /*******************************************************************************
@@ -82,7 +82,7 @@ public alias RedistributeInfo delegate (RequestContext) RedistributeDg;
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[])) GetValueDg;
+public alias void delegate (RequestContext, const(char[])) GetValueDg;
 
 
 /*******************************************************************************
@@ -91,7 +91,7 @@ public alias void delegate (RequestContext, Const!(char[])) GetValueDg;
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[]), Const!(char[]))
+public alias void delegate (RequestContext, const(char[]), const(char[]))
     GetPairDg;
 
 
@@ -110,7 +110,7 @@ public alias void delegate (RequestContext, bool) GetBoolDg;
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[]), ushort, HashRange)
+public alias void delegate (RequestContext, const(char[]), ushort, HashRange)
     GetResponsibleRangeDg;
 
 
@@ -121,7 +121,7 @@ public alias void delegate (RequestContext, Const!(char[]), ushort, HashRange)
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[]), ushort, size_t)
+public alias void delegate (RequestContext, const(char[]), ushort, size_t)
     GetNumConnectionsDg;
 
 
@@ -132,7 +132,7 @@ public alias void delegate (RequestContext, Const!(char[]), ushort, size_t)
 
 *******************************************************************************/
 
-public alias void delegate (RequestContext, Const!(char[]), ushort, Const!(char[]))
+public alias void delegate (RequestContext, const(char[]), ushort, const(char[]))
     GetNodeValueDg;
 
 

--- a/src/dlsproto/client/mixins/NeoSupport.d
+++ b/src/dlsproto/client/mixins/NeoSupport.d
@@ -187,8 +187,8 @@ template NeoSupport ()
                 time_t timestamp, C value, scope Put.Notifier notifier,
                 Options options )
         {
-            static assert(is(C: Const!(void)[]),"value must be implicitly castable to" ~
-                    " Const!(void)[]");
+            static assert(is(C: const(void)[]),"value must be implicitly castable to" ~
+                    " const(void)[]");
 
             RequestContext context;
             scope parse_context = (RequestContext context_)
@@ -197,8 +197,8 @@ template NeoSupport ()
             };
             setupOptionalArgs!(options.length)(options, parse_context);
 
-            auto params = Const!(Internals.Put.UserSpecifiedParams)(
-                    Const!(Put.Args)(channel, timestamp, value),
+            auto params = const(Internals.Put.UserSpecifiedParams)(
+                    const(Put.Args)(channel, timestamp, value),
                     notifier
                 );
 
@@ -254,8 +254,8 @@ template NeoSupport ()
                     parse_context
             );
 
-            auto params = Const!(Internals.GetRange.UserSpecifiedParams)(
-                        Const!(GetRange.Args)(channel, low, high,
+            auto params = const(Internals.GetRange.UserSpecifiedParams)(
+                        const(GetRange.Args)(channel, low, high,
                             filter_string, filter_mode, context),
                         notifier
                     );
@@ -421,7 +421,7 @@ template NeoSupport ()
             time_t key, C value,
             Options options)
         {
-            static assert(is(C: Const!(void)[]),"value must be implicitly castable to" ~
+            static assert(is(C: const(void)[]),"value must be implicitly castable to" ~
                     " void[]");
 
             auto task = Task.getThis();
@@ -455,7 +455,7 @@ template NeoSupport ()
                     parse_notifier
             );
 
-            scope notifier = ( Neo.Put.Notification info, Const!(Neo.Put.Args) args )
+            scope notifier = ( Neo.Put.Notification info, const(Neo.Put.Args) args )
             {
                 if ( user_notifier )
                     user_notifier(info, args);
@@ -575,7 +575,7 @@ template NeoSupport ()
             *******************************************************************/
 
             private void notifier ( DlsClient.Neo.GetRange.Notification info,
-                Const!(DlsClient.Neo.GetRange.Args) args )
+                const(DlsClient.Neo.GetRange.Args) args )
             {
                 if (this.user_notifier)
                 {
@@ -709,8 +709,8 @@ template NeoSupport ()
             time_t low, time_t high,
             Options options )
         {
-            static assert(is(C: Const!(void)[]),"value must be implicitly castable to" ~
-                    " Const!(void)[]");
+            static assert(is(C: const(void)[]),"value must be implicitly castable to" ~
+                    " const(void)[]");
 
             auto task = Task.getThis();
             verify(task !is null,
@@ -762,7 +762,7 @@ template NeoSupport ()
             }
 
             private void putNotifier ( DlsClient.Neo.Put.Notification info,
-                Const!(DlsClient.Neo.Put.Args) args )
+                const(DlsClient.Neo.Put.Args) args )
             {
             }
 

--- a/src/dlsproto/client/request/GetRange.d
+++ b/src/dlsproto/client/request/GetRange.d
@@ -129,7 +129,7 @@ public alias SmartUnion!(NotificationUnion) Notification;
 
 *******************************************************************************/
 
-public alias void delegate ( Notification, Const!(Args) ) Notifier;
+public alias void delegate ( Notification, const(Args) ) Notifier;
 
 /*******************************************************************************
 

--- a/src/dlsproto/client/request/Put.d
+++ b/src/dlsproto/client/request/Put.d
@@ -80,4 +80,4 @@ public alias SmartUnion!(NotificationUnion) Notification;
 
 *******************************************************************************/
 
-public alias void delegate ( Notification, Const!(Args) ) Notifier;
+public alias void delegate ( Notification, const(Args) ) Notifier;

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -620,7 +620,7 @@ private scope class GetRangeHandler
                     }
                 }
 
-                Const!(void)[] remaining_batch = *this.buffers.output;
+                const(void)[] remaining_batch = *this.buffers.output;
                 for (uint yield_count = 0; remaining_batch.length; yield_count++)
                 {
                     if (yield_count >= 10) //yield every 10 records
@@ -639,7 +639,7 @@ private scope class GetRangeHandler
                     this.passRecordToUser(
                         *this.outer.conn.message_parser.getValue!(time_t)(
                             remaining_batch),
-                        this.outer.conn.message_parser.getArray!(Const!(void))(
+                        this.outer.conn.message_parser.getArray!(const(void))(
                             remaining_batch
                         ));
 
@@ -819,7 +819,7 @@ private scope class GetRangeHandler
                         switch (msg.type)
                         {
                             case MessageType_v2.Records:
-                                Const!(void)[] received_record_batch;
+                                const(void)[] received_record_batch;
                                 size_t uncompressed_batch_size;
 
                                 this.outer.conn.message_parser.parseBody(

--- a/src/dlsproto/node/neo/request/GetRange.d
+++ b/src/dlsproto/node/neo/request/GetRange.d
@@ -145,7 +145,7 @@ public abstract class GetRangeProtocol_v2: IRequest
     ***************************************************************************/
 
     void handle ( RequestOnConn connection, Object resources,
-        Const!(void)[] init_payload )
+        const(void)[] init_payload )
     {
         this.initialise(connection, resources);
 

--- a/src/dlsproto/node/neo/request/Put.d
+++ b/src/dlsproto/node/neo/request/Put.d
@@ -50,13 +50,13 @@ public abstract class PutProtocol_v1: IRequest
     ***************************************************************************/
 
     void handle ( RequestOnConn connection, Object resources,
-        Const!(void)[] init_payload )
+        const(void)[] init_payload )
     {
         this.initialise(connection, resources);
 
         cstring channel;
         time_t timestamp;
-        Const!(char)[] value;
+        const(char)[] value;
         this.ed.message_parser.parseBody(init_payload, channel, timestamp, value);
 
         // Store the extracted data in StorageEngine

--- a/src/dlsproto/node/request/GetChannels.d
+++ b/src/dlsproto/node/request/GetChannels.d
@@ -82,5 +82,5 @@ public abstract scope class GetChannels : DlsCommand
 
     ***************************************************************************/
 
-    abstract protected Const!(char[])[] getChannelsIds ( );
+    abstract protected const(char[])[] getChannelsIds ( );
 }

--- a/src/fakedls/request/GetChannels.d
+++ b/src/fakedls/request/GetChannels.d
@@ -51,7 +51,7 @@ public scope class GetChannels : Protocol.GetChannels
 
     ***************************************************************************/
 
-    override protected Const!(char[])[] getChannelsIds ( )
+    override protected const(char[])[] getChannelsIds ( )
     {
         return global_storage.getChannelList();
     }

--- a/src/turtle/env/Dls.d
+++ b/src/turtle/env/Dls.d
@@ -133,7 +133,7 @@ public class Dls : Node!(DlsNode, "dls")
 
     ***************************************************************************/
 
-    public Const!(cstring[]) get ( cstring channel, size_t key )
+    public const(cstring[]) get ( cstring channel, size_t key )
     {
         // DLS protocol defines keys as strings but env.Dls tries to mimic
         // swarm client API which uses hash_t
@@ -158,7 +158,7 @@ public class Dls : Node!(DlsNode, "dls")
 
     ***************************************************************************/
 
-    public Const!(char[][])[hash_t] getAll ( cstring channel )
+    public const(char[][])[hash_t] getAll ( cstring channel )
     {
         return global_storage.getVerify(channel).getAll();
     }


### PR DESCRIPTION
D1 support was dropped in v15.x.x. This commit replaces the use of
`Const!` with D2 builtin `const` because `Const!` was only used to
transition to D2, i.e., it enabled us to D2 features while supporting
both D1 and D2. All usages of `Const!` in this code base are replaced.
Note, there are no uses of `Immut!` or `Inout!` in the code base.

Fixes sociomantic-tsunami/dlsproto#113.