### PR TITLE
Add support for Ubuntu bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,14 @@ jobs:
           env: DMD=2.086.* F=production
         - <<: *test-matrix
           env: DMD=2.086.* F=devel
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.078.3.s* F=production
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.078.3.s* F=devel
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.086.* F=production
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.086.* F=devel
         # Additional stages
 
         - stage: Closure allocation check

--- a/Build.mak
+++ b/Build.mak
@@ -1,9 +1,7 @@
 export ASSERT_ON_STOMPING_PREVENTION=1
 
 override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0 -lpcre
-override DFLAGS += -w
-
-override DFLAGS += -de
+override DFLAGS += -w -de
 
 $B/fakedls: $C/src/fakedls/main.d
 

--- a/Build.mak
+++ b/Build.mak
@@ -4,8 +4,6 @@ override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0 -lpcre
 override DFLAGS += -w
 
 override DFLAGS += -de
-# Open source Makd uses dmd by default
-DC = dmd-transitional
 
 $B/fakedls: $C/src/fakedls/main.d
 

--- a/Build.mak
+++ b/Build.mak
@@ -3,6 +3,12 @@ export ASSERT_ON_STOMPING_PREVENTION=1
 override LDFLAGS += -llzo2 -lebtree -lrt -lgcrypt -lgpg-error -lglib-2.0 -lpcre
 override DFLAGS += -w -de
 
+# Ubuntu bionic requires builds to use position independent code and
+# dmd-transitional does not set the flag -fPIC by default
+ifeq ($(DC),dmd-transitional)
+	override DFLAGS += -fPIC
+endif
+
 $B/fakedls: $C/src/fakedls/main.d
 
 all += $B/fakedls $B/neotest

--- a/Config.mak
+++ b/Config.mak
@@ -1,1 +1,4 @@
 DVER := 2
+
+# Open source Makd uses dmd by default
+DC := dmd-transitional

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/dlang:v3
+FROM sociomantictsunami/develdlang:v8


### PR DESCRIPTION
The dmd-transitional compiler is available for Ubuntu bionic only for
vesion 2.078.3.s*.