### PR TITLE
Remove all imports of ocean.transition

### DIFF
--- a/integrationtest/fakedls/main.d
+++ b/integrationtest/fakedls/main.d
@@ -14,7 +14,7 @@ module integrationtest.fakedls.main;
 
 import dlstest.TestRunner;
 import turtle.runner.Runner;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version ( unittest ) {}
 else

--- a/neotest/main.d
+++ b/neotest/main.d
@@ -10,7 +10,7 @@
 
 module test.neotest.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.Stdout;
 
 import ocean.task.Scheduler;

--- a/src/dlsproto/client/DlsClient.d
+++ b/src/dlsproto/client/DlsClient.d
@@ -162,7 +162,7 @@ import ocean.core.Enforce;
 
 debug ( SwarmClient ) import ocean.io.Stdout;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/DlsClient.d
+++ b/src/dlsproto/client/DlsClient.d
@@ -115,8 +115,6 @@ module dlsproto.client.DlsClient;
 
 *******************************************************************************/
 
-import ocean.transition;
-
 import ocean.core.Verify;
 
 import swarm.util.ExtensibleClass;

--- a/src/dlsproto/client/NotifierTypes.d
+++ b/src/dlsproto/client/NotifierTypes.d
@@ -12,7 +12,7 @@
 
 module dlsproto.client.NotifierTypes;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import core.stdc.time;
 
 /*******************************************************************************

--- a/src/dlsproto/client/UsageExamples.d
+++ b/src/dlsproto/client/UsageExamples.d
@@ -14,7 +14,7 @@ module dlsproto.client.UsageExamples;
 
 version ( unittest )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     import dlsproto.client.DlsClient;
 

--- a/src/dlsproto/client/internal/SharedResources.d
+++ b/src/dlsproto/client/internal/SharedResources.d
@@ -19,7 +19,7 @@ module dlsproto.client.internal.SharedResources;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/dlsproto/client/legacy/internal/RequestSetup.d
+++ b/src/dlsproto/client/legacy/internal/RequestSetup.d
@@ -37,7 +37,7 @@ public template IODelegate ( )
     import ocean.transition;
     import ocean.core.TypeConvert : downcast;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************
@@ -103,7 +103,7 @@ public template Filter ( )
     import ocean.transition;
     import ocean.core.TypeConvert : downcast;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************
@@ -273,7 +273,7 @@ public template Key ( )
     import ocean.core.TypeConvert : downcast;
     static import swarm.util.Hash;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************
@@ -367,7 +367,7 @@ public template Range ( )
     import ocean.core.TypeConvert : downcast;
     static import swarm.util.Hash;
 
-    mixin TypeofThis;
+    alias typeof(this) This;
     static assert (is(This == struct));
 
     /***************************************************************************

--- a/src/dlsproto/client/legacy/internal/RequestSetup.d
+++ b/src/dlsproto/client/legacy/internal/RequestSetup.d
@@ -64,10 +64,8 @@ public template IODelegate ( )
     public This* io ( T ) ( T io )
     {
         this.io_item = this.io_item(io);
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+
+        return &this;
     }
 
 
@@ -169,10 +167,7 @@ public template Filter ( )
                 assert(false, "filter method called on command which doesn't support filtering!");
         }
 
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+        return &this;
     }
 
 
@@ -215,10 +210,7 @@ public template Filter ( )
                 assert(false, "filter method called on command which doesn't support filtering!");
         }
 
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+        return &this;
     }
 
 
@@ -307,10 +299,7 @@ public template Key ( )
 
         this.hash = swarm.util.Hash.toHash(key);
 
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+        return &this;
     }
 
 
@@ -327,10 +316,7 @@ public template Key ( )
     {
         this.user_context = RequestContext(this.hash);
 
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+        return &this;
     }
 
 
@@ -401,10 +387,7 @@ public template Range ( )
             swarm.util.Hash.HashRange(swarm.util.Hash.toHash(start),
                     swarm.util.Hash.toHash(end));
 
-        version (D_Version2)
-            return &this;
-        else
-            return this;
+        return &this;
     }
 
 

--- a/src/dlsproto/client/legacy/internal/RequestSetup.d
+++ b/src/dlsproto/client/legacy/internal/RequestSetup.d
@@ -34,7 +34,7 @@ public import swarm.client.RequestSetup;
 
 public template IODelegate ( )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.TypeConvert : downcast;
 
     alias typeof(this) This;
@@ -98,7 +98,7 @@ public template IODelegate ( )
 
 public template Filter ( )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.TypeConvert : downcast;
 
     alias typeof(this) This;
@@ -261,7 +261,7 @@ public template Filter ( )
 
 public template Key ( )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.TypeConvert : downcast;
     static import swarm.util.Hash;
 
@@ -349,7 +349,7 @@ public template Key ( )
 
 public template Range ( )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.TypeConvert : downcast;
     static import swarm.util.Hash;
 

--- a/src/dlsproto/client/legacy/internal/connection/DlsNodeConnectionPool.d
+++ b/src/dlsproto/client/legacy/internal/connection/DlsNodeConnectionPool.d
@@ -47,7 +47,7 @@ import ocean.core.Enforce;
 
 import ocean.io.compress.lzo.LzoChunkCompressor;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/dlsproto/client/legacy/internal/connection/DlsRequestConnection.d
+++ b/src/dlsproto/client/legacy/internal/connection/DlsRequestConnection.d
@@ -55,7 +55,7 @@ import dlsproto.client.legacy.internal.request.PutBatchRequest;
 
 import dlsproto.client.legacy.DlsConst;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Enforce;
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/connection/SharedResources.d
+++ b/src/dlsproto/client/legacy/internal/connection/SharedResources.d
@@ -40,7 +40,7 @@ public import swarm.util.RecordBatcher : RecordBatch;
 
 import swarm.Const;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/dlsproto/client/legacy/internal/helper/GroupRequest.d
+++ b/src/dlsproto/client/legacy/internal/helper/GroupRequest.d
@@ -62,7 +62,7 @@ module dlsproto.client.legacy.internal.helper.GroupRequest;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import swarm.client.helper.GroupRequest;
 

--- a/src/dlsproto/client/legacy/internal/registry/DlsNodeRegistry.d
+++ b/src/dlsproto/client/legacy/internal/registry/DlsNodeRegistry.d
@@ -20,7 +20,7 @@ module dlsproto.client.legacy.internal.registry.DlsNodeRegistry;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/dlsproto/client/legacy/internal/request/GetAllFilterRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/GetAllFilterRequest.d
@@ -26,7 +26,7 @@ import dlsproto.client.legacy.internal.request.model.IBulkGetRequest;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/GetAllRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/GetAllRequest.d
@@ -26,7 +26,7 @@ import dlsproto.client.legacy.internal.request.model.IBulkGetRequest;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/GetRangeFilterRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/GetRangeFilterRequest.d
@@ -26,7 +26,7 @@ import dlsproto.client.legacy.internal.request.model.IBulkGetRequest;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/GetRangeRegexRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/GetRangeRegexRequest.d
@@ -24,7 +24,7 @@ private import dlsproto.client.legacy.internal.request.model.IBulkGetRequest;
 
 private import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/GetRangeRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/GetRangeRequest.d
@@ -26,7 +26,7 @@ import dlsproto.client.legacy.internal.request.model.IBulkGetRequest;
 
 import ocean.io.select.client.FiberSelectEvent;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/PutRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/PutRequest.d
@@ -24,7 +24,7 @@ module dlsproto.client.legacy.internal.request.PutRequest;
 
 import dlsproto.client.legacy.internal.request.model.IPutRequest;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/model/IBulkGetRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/model/IBulkGetRequest.d
@@ -28,7 +28,7 @@ module dlsproto.client.legacy.internal.request.model.IBulkGetRequest;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import swarm.Const : NodeItem;
 

--- a/src/dlsproto/client/legacy/internal/request/model/IPutRequest.d
+++ b/src/dlsproto/client/legacy/internal/request/model/IPutRequest.d
@@ -30,7 +30,7 @@ import swarm.client.ClientExceptions;
 
 import ocean.core.Enforce;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/dlsproto/client/legacy/internal/request/params/IODelegates.d
+++ b/src/dlsproto/client/legacy/internal/request/params/IODelegates.d
@@ -21,7 +21,7 @@ module dlsproto.client.legacy.internal.request.params.IODelegates;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import swarm.client.request.context.RequestContext;
 

--- a/src/dlsproto/client/legacy/internal/request/params/RequestParams.d
+++ b/src/dlsproto/client/legacy/internal/request/params/RequestParams.d
@@ -20,7 +20,7 @@ module dlsproto.client.legacy.internal.request.params.RequestParams;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/dlsproto/client/request/GetRange.d
+++ b/src/dlsproto/client/request/GetRange.d
@@ -18,7 +18,7 @@ module dlsproto.client.request.GetRange;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.SmartUnion;
 public import swarm.neo.client.NotifierTypes;
 public import dlsproto.client.NotifierTypes;

--- a/src/dlsproto/client/request/Put.d
+++ b/src/dlsproto/client/request/Put.d
@@ -18,7 +18,7 @@ module dlsproto.client.request.Put;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.SmartUnion;
 public import swarm.neo.client.NotifierTypes;
 public import swarm.neo.client.request_options.RequestContext;

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -20,7 +20,7 @@ module dlsproto.client.request.internal.GetRange;
 
 import core.stdc.time;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.VersionCheck;
 import ocean.core.Verify;
 import ocean.util.log.Logger;
@@ -71,7 +71,7 @@ public struct GetRange
     import dlsproto.client.internal.SharedResources;
 
     import ocean.io.select.protocol.generic.ErrnoIOException: IOError;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     import swarm.neo.client.mixins.AllNodesRequestCore;
     import swarm.neo.client.mixins.BatchRequestCore;

--- a/src/dlsproto/client/request/internal/GetRange.d
+++ b/src/dlsproto/client/request/internal/GetRange.d
@@ -80,7 +80,7 @@ public struct GetRange
     import swarm.neo.client.RequestOnConn;
     import swarm.neo.client.IRequestSet;
 
-    mixin TypeofThis!();
+    alias typeof(this) This;
 
 
     /***************************************************************************

--- a/src/dlsproto/client/request/internal/Put.d
+++ b/src/dlsproto/client/request/internal/Put.d
@@ -18,7 +18,7 @@ module dlsproto.client.request.internal.Put;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Logger;
 
 /*******************************************************************************

--- a/src/dlsproto/common/GetRange.d
+++ b/src/dlsproto/common/GetRange.d
@@ -18,7 +18,7 @@ module dlsproto.common.GetRange;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import swarm.neo.request.Command;
 
 /*******************************************************************************

--- a/src/dlsproto/node/neo/request/GetRange.d
+++ b/src/dlsproto/node/neo/request/GetRange.d
@@ -48,7 +48,7 @@ public abstract class GetRangeProtocol_v2: IRequest
 
     import ocean.core.Enforce;
     import ocean.io.compress.Lzo;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dlsproto/node/neo/request/Put.d
+++ b/src/dlsproto/node/neo/request/Put.d
@@ -21,7 +21,7 @@ public abstract class PutProtocol_v1: IRequest
 
     import swarm.neo.node.RequestOnConn;
     import dlsproto.common.Put;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import core.stdc.time;
 
     /***************************************************************************

--- a/src/dlsproto/node/request/GetAll.d
+++ b/src/dlsproto/node/request/GetAll.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetAll;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.CompressedBatch;
 

--- a/src/dlsproto/node/request/GetAllFilter.d
+++ b/src/dlsproto/node/request/GetAllFilter.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetAllFilter;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.CompressedBatch;
 

--- a/src/dlsproto/node/request/GetChannels.d
+++ b/src/dlsproto/node/request/GetChannels.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetChannels;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.DlsCommand;
 

--- a/src/dlsproto/node/request/GetNumConnections.d
+++ b/src/dlsproto/node/request/GetNumConnections.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetNumConnections;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.DlsCommand;
 

--- a/src/dlsproto/node/request/GetRange.d
+++ b/src/dlsproto/node/request/GetRange.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetRange;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.CompressedBatch;
 

--- a/src/dlsproto/node/request/GetRangeFilter.d
+++ b/src/dlsproto/node/request/GetRangeFilter.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetRangeFilter;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.CompressedBatch;
 

--- a/src/dlsproto/node/request/GetRangeRegex.d
+++ b/src/dlsproto/node/request/GetRangeRegex.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetRangeRegex;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.CompressedBatch;
 

--- a/src/dlsproto/node/request/GetVersion.d
+++ b/src/dlsproto/node/request/GetVersion.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.GetVersion;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.DlsCommand;
 

--- a/src/dlsproto/node/request/Put.d
+++ b/src/dlsproto/node/request/Put.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.Put;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.SingleChannel;
 

--- a/src/dlsproto/node/request/PutBatch.d
+++ b/src/dlsproto/node/request/PutBatch.d
@@ -20,7 +20,7 @@ module dlsproto.node.request.PutBatch;
 
 import dlsproto.node.request.model.SingleChannel;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/dlsproto/node/request/Redistribute.d
+++ b/src/dlsproto/node/request/Redistribute.d
@@ -18,8 +18,6 @@ module dlsproto.node.request.Redistribute;
 
 ******************************************************************************/
 
-import ocean.transition;
-
 import dlsproto.node.request.model.DlsCommand;
 import ocean.transition;
 import ocean.util.log.Logger;

--- a/src/dlsproto/node/request/Redistribute.d
+++ b/src/dlsproto/node/request/Redistribute.d
@@ -19,7 +19,7 @@ module dlsproto.node.request.Redistribute;
 ******************************************************************************/
 
 import dlsproto.node.request.model.DlsCommand;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Logger;
 import dlsproto.client.legacy.DlsConst;
 

--- a/src/dlsproto/node/request/RemoveChannel.d
+++ b/src/dlsproto/node/request/RemoveChannel.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.RemoveChannel;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.SingleChannel;
 

--- a/src/dlsproto/node/request/model/CompressedBatch.d
+++ b/src/dlsproto/node/request/model/CompressedBatch.d
@@ -20,7 +20,7 @@ module dlsproto.node.request.model.CompressedBatch;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import dlsproto.node.request.model.SingleChannel;

--- a/src/dlsproto/node/request/model/DlsCommand.d
+++ b/src/dlsproto/node/request/model/DlsCommand.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.model.DlsCommand;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import swarm.node.protocol.Command;

--- a/src/dlsproto/node/request/model/SingleChannel.d
+++ b/src/dlsproto/node/request/model/SingleChannel.d
@@ -18,7 +18,7 @@ module dlsproto.node.request.model.SingleChannel;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.node.request.model.DlsCommand;
 import ocean.text.convert.Formatter;

--- a/src/dlstest/DlsClient.d
+++ b/src/dlstest/DlsClient.d
@@ -19,7 +19,7 @@ module dlstest.DlsClient;
 
 ******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.core.VersionCheck;
 import ocean.util.log.Logger;

--- a/src/dlstest/DlsTestCase.d
+++ b/src/dlstest/DlsTestCase.d
@@ -32,7 +32,7 @@ abstract class DlsTestCase : TestCase
 {
     import ocean.core.Test; // makes `test` available in derivatives
     import dlstest.DlsClient;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dlstest/TestRunner.d
+++ b/src/dlstest/TestRunner.d
@@ -20,7 +20,7 @@ module dlstest.TestRunner;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import turtle.runner.Runner;
 

--- a/src/dlstest/cases/legacy/Basic.d
+++ b/src/dlstest/cases/legacy/Basic.d
@@ -20,7 +20,7 @@ module dlstest.cases.legacy.Basic;
 
 import ocean.core.Array;
 import ocean.core.Test;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlstest.DlsTestCase;
 

--- a/src/dlstest/cases/legacy/Ranges.d
+++ b/src/dlstest/cases/legacy/Ranges.d
@@ -18,7 +18,7 @@ module dlstest.cases.legacy.Ranges;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Array;
 import ocean.core.Test;
 import dlstest.DlsClient;

--- a/src/dlstest/cases/neo/Dummy.d
+++ b/src/dlstest/cases/neo/Dummy.d
@@ -16,7 +16,7 @@
 
 module dlstest.cases.neo.Dummy;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlstest.DlsTestCase;
 

--- a/src/dlstest/util/LocalStore.d
+++ b/src/dlstest/util/LocalStore.d
@@ -26,7 +26,7 @@ struct LocalStore
     import turtle.runner.Logging;
     import ocean.core.Array : contains;
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/dlstest/util/Record.d
+++ b/src/dlstest/util/Record.d
@@ -19,7 +19,7 @@ public struct Record
 {
     import ocean.io.digest.Fnv1;
     import ocean.text.convert.Formatter;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/fakedls/ConnectionHandler.d
+++ b/src/fakedls/ConnectionHandler.d
@@ -18,7 +18,7 @@ module fakedls.ConnectionHandler;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.net.server.connection.IConnectionHandler;
 import swarm.node.connection.ConnectionHandler;

--- a/src/fakedls/DlsNode.d
+++ b/src/fakedls/DlsNode.d
@@ -19,7 +19,7 @@ module fakedls.DlsNode;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.log.Logger;
 

--- a/src/fakedls/Storage.d
+++ b/src/fakedls/Storage.d
@@ -20,7 +20,7 @@ module fakedls.Storage;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 import Hash = swarm.util.Hash;

--- a/src/fakedls/main.d
+++ b/src/fakedls/main.d
@@ -19,7 +19,7 @@ module fakedls.main;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import fakedls.DlsNode;
 

--- a/src/fakedls/mixins/ChannelIteration.d
+++ b/src/fakedls/mixins/ChannelIteration.d
@@ -27,7 +27,7 @@ public template ChannelIteration ( alias predicate = alwaysTrue )
 {
     import fakedls.Storage;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/fakedls/neo/SharedResources.d
+++ b/src/fakedls/neo/SharedResources.d
@@ -12,7 +12,7 @@
 
 module fakedls.neo.SharedResources;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.ReusableException;
 
 import dlsproto.node.neo.request.core.IRequestResources;

--- a/src/fakedls/neo/request/GetRange.d
+++ b/src/fakedls/neo/request/GetRange.d
@@ -22,7 +22,7 @@ import swarm.neo.request.Command;
 import dlsproto.common.RequestCodes;
 import ocean.text.convert.Integer;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import fakedls.neo.SharedResources;
 
 

--- a/src/fakedls/neo/request/Put.d
+++ b/src/fakedls/neo/request/Put.d
@@ -18,7 +18,7 @@ import swarm.neo.node.RequestOnConn;
 import swarm.neo.request.Command;
 import dlsproto.common.RequestCodes;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/fakedls/request/GetAllFilter.d
+++ b/src/fakedls/request/GetAllFilter.d
@@ -18,7 +18,7 @@ module fakedls.request.GetAllFilter;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.GetAllFilter;
 

--- a/src/fakedls/request/GetChannels.d
+++ b/src/fakedls/request/GetChannels.d
@@ -18,7 +18,7 @@ module fakedls.request.GetChannels;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.GetChannels;
 

--- a/src/fakedls/request/GetNumConnections.d
+++ b/src/fakedls/request/GetNumConnections.d
@@ -18,7 +18,7 @@ module fakedls.request.GetNumConnections;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.GetNumConnections;
 

--- a/src/fakedls/request/GetRange.d
+++ b/src/fakedls/request/GetRange.d
@@ -18,7 +18,7 @@ module fakedls.request.GetRange;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.GetRange;
 

--- a/src/fakedls/request/GetRangeFilter.d
+++ b/src/fakedls/request/GetRangeFilter.d
@@ -18,7 +18,7 @@ module fakedls.request.GetRangeFilter;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.GetRangeFilter;
 

--- a/src/fakedls/request/GetRangeRegex.d
+++ b/src/fakedls/request/GetRangeRegex.d
@@ -18,7 +18,7 @@ module fakedls.request.GetRangeRegex;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.GetRangeRegex;
 

--- a/src/fakedls/request/Put.d
+++ b/src/fakedls/request/Put.d
@@ -18,7 +18,7 @@ module fakedls.request.Put;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.Put;
 

--- a/src/fakedls/request/PutBatch.d
+++ b/src/fakedls/request/PutBatch.d
@@ -20,7 +20,7 @@ module fakedls.request.PutBatch;
 
 import Protocol = dlsproto.node.request.PutBatch;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import dlsproto.client.legacy.DlsConst;
 

--- a/src/fakedls/request/Redistribute.d
+++ b/src/fakedls/request/Redistribute.d
@@ -18,7 +18,7 @@ module fakedls.request.Redistribute;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.Redistribute;
 import dlsproto.client.legacy.DlsConst;

--- a/src/fakedls/request/RemoveChannel.d
+++ b/src/fakedls/request/RemoveChannel.d
@@ -18,7 +18,7 @@ module fakedls.request.RemoveChannel;
 
 *******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Protocol = dlsproto.node.request.RemoveChannel;
 

--- a/src/turtle/env/Dls.d
+++ b/src/turtle/env/Dls.d
@@ -26,8 +26,8 @@ import ocean.core.Verify;
 
 import turtle.env.model.Node;
 
+import ocean.meta.types.Qualifiers;
 import ocean.task.util.Timer;
-import ocean.transition;
 
 import fakedls.DlsNode;
 import fakedls.Storage;

--- a/src/turtle/env/Dls.d
+++ b/src/turtle/env/Dls.d
@@ -22,7 +22,6 @@ module turtle.env.Dls;
 *******************************************************************************/
 
 import ocean.core.Test : TestException;
-import ocean.transition;
 import ocean.core.Verify;
 
 import turtle.env.model.Node;


### PR DESCRIPTION
The ocean.transition module was created to ease D2 conversion. It can now be replaced with more appropriate imports.